### PR TITLE
test: addd test for updating only the customer's name

### DIFF
--- a/src/test/java/com/krishna/customer/CustomerServiceTest.java
+++ b/src/test/java/com/krishna/customer/CustomerServiceTest.java
@@ -182,4 +182,32 @@ class CustomerServiceTest {
         assertThat(capturedCustomer.getAge()).isEqualTo(updateRequest.age());
         assertThat(capturedCustomer.getEmail()).isEqualTo(updateRequest.email());
     }
+
+    @Test
+    void canUpdateOnlyCustomerName() {
+        // GIVEN
+        int id = 10;
+        Customer customer = new Customer(
+                id,
+                "krishna",
+                "dai@gmail.com",
+                12
+        );
+        when(customerDao.selectCustomerById(id)).thenReturn(Optional.of(customer));
+
+        CustomerUpdateRequest updateRequest = new CustomerUpdateRequest("krishna dai", null, null);
+
+        // WHEN
+        underTest.updateCustomer(id, updateRequest);
+
+        // THEN
+        ArgumentCaptor<Customer> customerArgumentCaptor = ArgumentCaptor.forClass(Customer.class);
+
+        verify(customerDao).updateCustomer(customerArgumentCaptor.capture());
+        Customer capturedCustomer = customerArgumentCaptor.getValue();
+
+        assertThat(capturedCustomer.getName()).isEqualTo(updateRequest.name());
+        assertThat(capturedCustomer.getAge()).isEqualTo(customer.getAge());
+        assertThat(capturedCustomer.getEmail()).isEqualTo(customer.getEmail());
+    }
 }


### PR DESCRIPTION
               - Introduced canUpdateOnlyCustomerName test method to validate partial updates.
               - Ensured that only the customer's name is updated while retaining existing email and age.
               - Used ArgumentCaptor to capture and verify the updated Customer object.
               - Added assertions to confirm the correctness of updated and retained properties.