### PR TITLE
test: add test for updating only the customer's age

### DIFF
--- a/src/test/java/com/krishna/customer/CustomerServiceTest.java
+++ b/src/test/java/com/krishna/customer/CustomerServiceTest.java
@@ -230,4 +230,27 @@ class CustomerServiceTest {
         assertThat(capturedCustomer.getAge()).isEqualTo(customer.getAge());
         assertThat(capturedCustomer.getEmail()).isEqualTo(newEmail);
     }
+
+    @Test
+    void canUpdateOnlyCustomerAge() {
+        // GIVEN
+        int id = 10;
+        Customer customer = new Customer(
+                id,
+                "krishna",
+                "dai@gmail.com",
+                12
+        );
+        when(customerDao.selectCustomerById(id)).thenReturn(Optional.of(customer));
+        CustomerUpdateRequest updateRequest = new CustomerUpdateRequest(null, null, 21);
+        // WHEN
+        underTest.updateCustomer(id, updateRequest);
+        // THEN
+        ArgumentCaptor<Customer> customerArgumentCaptor = ArgumentCaptor.forClass(Customer.class);
+        verify(customerDao).updateCustomer(customerArgumentCaptor.capture());
+        Customer capturedCustomer = customerArgumentCaptor.getValue();
+        assertThat(capturedCustomer.getName()).isEqualTo(customer.getName());
+        assertThat(capturedCustomer.getAge()).isEqualTo(updateRequest.age());
+        assertThat(capturedCustomer.getEmail()).isEqualTo(customer.getEmail());
+    }
 }


### PR DESCRIPTION
                                             - Introduced canUpdateOnlyCustomerAge test method to validate partial updates.
                                             - Ensured that only the customer's age is updated while retaining existing name and email.
                                             - Used ArgumentCaptor to capture and verify the updated Customer object.
                                             - Added assertions to confirm the correctness of updated and retained properties.